### PR TITLE
Bugfix: 'out of data' error message

### DIFF
--- a/groups.coffee
+++ b/groups.coffee
@@ -37,7 +37,7 @@ class GroupsPage extends Controller
     @el.on 'click', 'a[data-group]', ->
       group_id = @.getAttribute 'data-group'
       if group_id == 'all'
-        group_id = true
+        group_id = 'random'
         localStorage.removeItem 'active-group'
       else 
         localStorage.setItem 'active-group', group_id

--- a/overrides.coffee
+++ b/overrides.coffee
@@ -37,8 +37,8 @@ ClassifyPage::template = require './templates/classify-page'
 
 ClassifyPage::onNoMoreSubjects = ()->
   # fall back from /groups{group_id}/subjects to /groups/subjects
-  if typeof @Subject.group is 'string'
-    @Subject.group = true
+  if @Subject.group is not 'random'
+    @Subject.group = 'random'
     localStorage.removeItem 'active-group'
     @Subject.next()
   # otherwise, there really aren't any subjects left

--- a/project.coffee
+++ b/project.coffee
@@ -12,7 +12,7 @@ subjectGroup = localStorage.getItem 'active-group'
 module.exports =
   id: 'illustratedlife'
   background: 'background.jpg'
-  subjectGroup: subjectGroup ? true
+  subjectGroup: subjectGroup ? 'random'
   groups: group_page.groups
 
   title: 'Science Gossip'


### PR DESCRIPTION
Workaround Subject.next() sometimes returning 0 subjects by setting the default API endpoint to groups/random/subjects